### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -91,6 +91,10 @@ func extractFirstImageFromZip(zipPath, outputFolder string) error {
 
 	for _, file := range reader.File {
 		if isImageFile(file.Name) {
+			// Validate the file path
+			if !isValidPath(file.Name, outputFolder) {
+				return fmt.Errorf("invalid file path: %s", file.Name)
+			}
 			return extractZipFile(file, outputFolder)
 		}
 	}
@@ -140,6 +144,23 @@ func extractZipFile(file *zip.File, outputFolder string) error {
 
 	_, err = io.Copy(dst, src)
 	return err
+}
+
+func isValidPath(fileName, outputFolder string) bool {
+	// Check for directory traversal
+	if strings.Contains(fileName, "..") {
+		return false
+	}
+	// Ensure the file path is within the output folder
+	absOutputFolder, err := filepath.Abs(outputFolder)
+	if err != nil {
+		return false
+	}
+	absFilePath, err := filepath.Abs(filepath.Join(outputFolder, fileName))
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(absFilePath, absOutputFolder)
 }
 
 func extractRarFile(reader io.Reader, fileName, outputFolder string) error {


### PR DESCRIPTION
Fixes [https://github.com/alexander-bruun/magi/security/code-scanning/1](https://github.com/alexander-bruun/magi/security/code-scanning/1)

To fix the problem, we need to ensure that the file paths extracted from the zip archive do not contain any directory traversal elements such as `..`. This can be achieved by checking the file paths before using them in file system operations.

The best way to fix this issue without changing the existing functionality is to add a validation step that ensures the file paths are safe. Specifically, we should:
1. Check that the file name does not contain `..`.
2. Ensure that the file path is within the intended output directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
