### PR TITLE
Fix code scanning alert no. 3: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -90,7 +90,7 @@ func extractFirstImageFromZip(zipPath, outputFolder string) error {
 	defer reader.Close()
 
 	for _, file := range reader.File {
-		if strings.Contains(fileName, "..") {
+		if !strings.Contains(file.Name, "..") {
 			if isImageFile(file.Name) {
 				return extractZipFile(file, outputFolder)
 			}
@@ -133,7 +133,10 @@ func extractZipFile(file *zip.File, outputFolder string) error {
 	}
 	defer src.Close()
 
-	outputPath := filepath.Join(outputFolder, filepath.Base(file.Name))
+	outputPath := filepath.Join(outputFolder, file.Name)
+	if !strings.HasPrefix(filepath.Clean(outputPath), filepath.Clean(outputFolder) + string(os.PathSeparator)) {
+		return fmt.Errorf("invalid file path: %s", outputPath)
+	}
 	dst, err := os.Create(outputPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes [https://github.com/alexander-bruun/magi/security/code-scanning/3](https://github.com/alexander-bruun/magi/security/code-scanning/3)

To fix the problem, we need to ensure that the file paths extracted from the zip archive do not contain any directory traversal elements like `..`. This can be achieved by validating the file paths before using them in file system operations. Specifically, we should:
1. Correctly check for the presence of `..` in the file name.
2. Ensure that the file path is within the intended output directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
