### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
 
   create-release:
     name: Create Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs:
       - semantic


### PR DESCRIPTION
Potential fix for [https://github.com/alexander-bruun/magi/security/code-scanning/14](https://github.com/alexander-bruun/magi/security/code-scanning/14)

To fix the problem, you should define a `permissions` block for the `create-release` job (or at the workflow root). The minimal required permissions should be set; at minimum, jobs that mutate releases or upload assets will require `contents: write`. You can start the block as `contents: write` for this job, and if you later wish to further limit it (by scoping to a narrower set), you can refine as appropriate. Place the following under the `create-release` job key before `runs-on`.

**Steps to fix:**
- Locate the `create-release` job in `.github/workflows/ci.yml`.
- Under the key `create-release:`, add a `permissions:` block.
- Set `contents: write` within that block, properly indented.

No imports or additional dependencies are needed. The edit is entirely within the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
