### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Build Docker Images & binaries and Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/alexander-bruun/magi/security/code-scanning/11](https://github.com/alexander-bruun/magi/security/code-scanning/11)

To fix this issue, explicitly specify the least privileges required for the GITHUB_TOKEN by adding a `permissions` block. For most jobs, especially those that read the repository and do not push code or create issues/releases, this should be `permissions: contents: read`. For workflow consistency and maintainability, and unless a job needs higher privilege, you should apply this at the workflow root so it applies to all jobs. If specific jobs need custom permissions, override the `permissions` block at the job level. In this case, starting by adding:
```yaml
permissions:
  contents: read
```
immediately after the `name:` key (before `on:`), ensures least privilege by default for every job in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
