### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Build Docker Images & binaries and Release
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -151,6 +154,8 @@ jobs:
       - build
       - merge
     if: needs.semantic.outputs.version != ''  # Run only if a new version is available
+    permissions:
+      contents: write
 
     steps:
       - name: Install git


### PR DESCRIPTION
Potential fix for [https://github.com/alexander-bruun/magi/security/code-scanning/13](https://github.com/alexander-bruun/magi/security/code-scanning/13)

To fix the issue, we should add a `permissions` block to the workflow (ideally at the top level, thereby applying to all jobs), or to individual jobs if stricter granularity is needed.  
- As a safe starting point, use the minimal recommended permissions:  
  ```yaml
  permissions:
    contents: read
  ```
  This will restrict the GITHUB_TOKEN to read access to repository contents.  
- If any jobs require additional permissions (such as creating releases or writing pull requests), add those permissions explicitly to only those jobs.
- In this case, "merge" likely only needs `contents: read`, because the push to Docker is managed via Docker credentials, not GITHUB_TOKEN.  
- The "create-release" job may need `contents: write` (to publish a release), so that job should have elevated permissions.  
Action:  
- Add a top-level `permissions` block for safe defaults.  
- Add a per-job `permissions` block to the `create-release` job (if needed) to restore necessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
